### PR TITLE
Derive initial events from initial interest

### DIFF
--- a/src/tick.rs
+++ b/src/tick.rs
@@ -49,7 +49,7 @@ impl<T: TryAccept + Evented, F: ProtocolFactory<T::Output>> Tick<T, F> where <T 
     }
 
     pub fn stream(&mut self, transport: T::Output) -> ::Result<::Id> {
-        self.handler.stream(&mut self.event_loop, transport, EventSet::writable()).map(::Id)
+        self.handler.stream(&mut self.event_loop, transport).map(::Id)
     }
 
     pub fn run_until_complete(&mut self, id: ::Id) -> ::Result<()> {


### PR DESCRIPTION
Some protocols (SMTP being one example) require the server to start writing after accepting a connection. Currently, tick expects the server to start reading and a client to start writing.

This patch derives the initial set of events from the `Interest` returned as part of `ProtocolFactory.create()`. It panics on `Interest::Wait` and `Interest::Remove` which isn't ideal but then again, they are only mildly useful at that stage, anyway.
